### PR TITLE
Removing of deprecathed methods startLeScan and stopLeScan - Lollipop full support

### DIFF
--- a/BLE_myo/app/build.gradle
+++ b/BLE_myo/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "example.naoki.ble_myo"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 21
         versionCode 1
         versionName "1.0"

--- a/BLE_myo/app/src/main/java/example/naoki/ble_myo/ListActivity.java
+++ b/BLE_myo/app/src/main/java/example/naoki/ble_myo/ListActivity.java
@@ -4,6 +4,9 @@ import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothManager;
+import android.bluetooth.le.BluetoothLeScanner;
+import android.bluetooth.le.ScanCallback;
+import android.bluetooth.le.ScanResult;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
@@ -19,9 +22,8 @@ import android.widget.ListView;
 import android.widget.Toast;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 
-public class ListActivity extends ActionBarActivity implements BluetoothAdapter.LeScanCallback {
+public class ListActivity extends ActionBarActivity {
     public static final int MENU_SCAN = 0;
     public static final int LIST_DEVICE_MAX = 5;
 
@@ -33,12 +35,12 @@ public class ListActivity extends ActionBarActivity implements BluetoothAdapter.
     private Handler mHandler;
     private BluetoothAdapter mBluetoothAdapter;
     private BluetoothGatt    mBluetoothGatt;
+    private BluetoothLeScanner mBluetoothScanner;
+    private ScanMyoListCallback mCallback;
     private ArrayList<String> deviceNames = new ArrayList<>();
     private String myoName = null;
 
     private ArrayAdapter<String> adapter;
-
-
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -47,6 +49,9 @@ public class ListActivity extends ActionBarActivity implements BluetoothAdapter.
 
         BluetoothManager mBluetoothManager = (BluetoothManager) getSystemService(BLUETOOTH_SERVICE);
         mBluetoothAdapter = mBluetoothManager.getAdapter();
+        mBluetoothScanner = mBluetoothAdapter.getBluetoothLeScanner();
+        mCallback = new ScanMyoListCallback();
+
         mHandler = new Handler();
 
         ListView lv = (ListView) findViewById(R.id.listView1);
@@ -107,28 +112,6 @@ public class ListActivity extends ActionBarActivity implements BluetoothAdapter.
         scanDevice();
     }
 
-    @Override
-    public void onLeScan(BluetoothDevice device, int rssi, byte[] scanRecord) {
-    // Device Log
-        ParcelUuid[] uuids = device.getUuids();
-        String uuid = "";
-        if (uuids != null) {
-            for (ParcelUuid puuid : uuids) {
-                uuid += puuid.toString() + " ";
-            }
-        }
-
-        String msg = "name=" + device.getName() + ", bondStatus="
-                + device.getBondState() + ", address="
-                + device.getAddress() + ", type" + device.getType()
-                + ", uuids=" + uuid;
-        Log.d("BLEActivity", msg);
-
-        if (device.getName() != null && !deviceNames.contains(device.getName())) {
-            deviceNames.add(device.getName());
-        }
-    }
-
     public void scanDevice() {
         deviceNames.clear();
         // Scanning Time out by Handler.
@@ -136,14 +119,38 @@ public class ListActivity extends ActionBarActivity implements BluetoothAdapter.
         mHandler.postDelayed(new Runnable() {
             @Override
             public void run() {
-                mBluetoothAdapter.stopLeScan(ListActivity.this);
+                mBluetoothScanner.stopScan(mCallback);
 
                 adapter.notifyDataSetChanged();
                 Toast.makeText(getApplicationContext(), "Stop Device Scan", Toast.LENGTH_SHORT).show();
 
             }
         }, SCAN_PERIOD);
-        mBluetoothAdapter.startLeScan(ListActivity.this);
+        mBluetoothScanner.startScan(mCallback);
     }
 
+    protected class ScanMyoListCallback extends ScanCallback {
+        @Override
+        public void onScanResult(int callbackType, ScanResult result) {
+            super.onScanResult(callbackType, result);
+            BluetoothDevice device = result.getDevice();
+            ParcelUuid[] uuids = device.getUuids();
+            String uuid = "";
+            if (uuids != null) {
+                for (ParcelUuid puuid : uuids) {
+                    uuid += puuid.toString() + " ";
+                }
+            }
+
+            String msg = "name=" + device.getName() + ", bondStatus="
+                    + device.getBondState() + ", address="
+                    + device.getAddress() + ", type" + device.getType()
+                    + ", uuids=" + uuid;
+            Log.d("BLEActivity", msg);
+
+            if (device.getName() != null && !deviceNames.contains(device.getName())) {
+                deviceNames.add(device.getName());
+            }
+        }
+    }
 }

--- a/BLE_myo/app/src/main/java/example/naoki/ble_myo/MainActivity.java
+++ b/BLE_myo/app/src/main/java/example/naoki/ble_myo/MainActivity.java
@@ -1,6 +1,10 @@
 package example.naoki.ble_myo;
 
+import android.bluetooth.le.BluetoothLeScanner;
+import android.bluetooth.le.ScanCallback;
+import android.bluetooth.le.ScanResult;
 import android.content.Intent;
+import android.os.ParcelUuid;
 import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
 import android.os.Handler;
@@ -13,19 +17,9 @@ import android.bluetooth.BluetoothManager;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGatt;
-import android.bluetooth.BluetoothProfile;
-import android.bluetooth.BluetoothGattCallback;
-import android.bluetooth.BluetoothGattCharacteristic;
-import android.bluetooth.BluetoothGattDescriptor;
-import android.bluetooth.BluetoothGattService;
 
 import android.widget.TextView;
 import android.widget.Toast;
-
-import java.util.ArrayList;
-import java.util.UUID;
-import java.util.Queue;
-import java.util.LinkedList;
 
 public class MainActivity extends ActionBarActivity implements BluetoothAdapter.LeScanCallback {
     public static final int MENU_LIST = 0;
@@ -41,6 +35,8 @@ public class MainActivity extends ActionBarActivity implements BluetoothAdapter.
     private BluetoothGatt    mBluetoothGatt;
     private TextView         emgDataText;
     private TextView         gestureText;
+    private BluetoothLeScanner mBluetoothScanner;
+    private ScanMyoCallback mCallback;
 
     private MyoGattCallback mMyoCallback;
     private MyoCommandList commandList = new MyoCommandList();
@@ -65,6 +61,9 @@ public class MainActivity extends ActionBarActivity implements BluetoothAdapter.
 
         BluetoothManager mBluetoothManager = (BluetoothManager) getSystemService(BLUETOOTH_SERVICE);
         mBluetoothAdapter = mBluetoothManager.getAdapter();
+        mBluetoothScanner = mBluetoothAdapter.getBluetoothLeScanner();
+        mCallback = new ScanMyoCallback();
+
 
         Intent intent = getIntent();
         deviceName = intent.getStringExtra(ListActivity.TAG);
@@ -75,10 +74,10 @@ public class MainActivity extends ActionBarActivity implements BluetoothAdapter.
             mHandler.postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    mBluetoothAdapter.stopLeScan(MainActivity.this);
+                    mBluetoothScanner.stopScan(mCallback);
                 }
             }, SCAN_PERIOD);
-            mBluetoothAdapter.startLeScan(this);
+            mBluetoothScanner.startScan(mCallback);
         }
     }
 
@@ -122,7 +121,7 @@ public class MainActivity extends ActionBarActivity implements BluetoothAdapter.
     @Override
     public void onLeScan(BluetoothDevice device, int rssi, byte[] scanRecord) {
         if (deviceName.equals(device.getName())) {
-            mBluetoothAdapter.stopLeScan(this);
+            mBluetoothScanner.stopScan(mCallback);
             // Trying to connect GATT
             mMyoCallback = new MyoGattCallback(mHandler, emgDataText);
             mBluetoothGatt = device.connectGatt(this, false, mMyoCallback);
@@ -216,6 +215,21 @@ public class MainActivity extends ActionBarActivity implements BluetoothAdapter.
                 gestureText.setText(message);
             }
         });
+    }
+
+    protected class ScanMyoCallback extends ScanCallback {
+        @Override
+        public void onScanResult(int callbackType, ScanResult result) {
+            super.onScanResult(callbackType, result);
+            BluetoothDevice device = result.getDevice();
+            if (deviceName.equals(device.getName())) {
+                mBluetoothScanner.stopScan(mCallback);
+                // Trying to connect GATT
+                mMyoCallback = new MyoGattCallback(mHandler, emgDataText);
+                mBluetoothGatt = device.connectGatt(MainActivity.this, false, mMyoCallback);
+                mMyoCallback.setBluetoothGatt(mBluetoothGatt);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
This pull request remove deprecated methods `startLeScan` and `stopLeScan` (from api 21 they are deprecated). New method `startScan` and `stopScan` are introduced instead.

Please note that I've modified file `build.gradle` changing `minSdkVersion` from 19 to 21, since new methods are not present in api 19.
