### PR TITLE
Adding check on Bluetooth power state

### DIFF
--- a/BLE_myo/app/src/main/java/example/naoki/ble_myo/ListActivity.java
+++ b/BLE_myo/app/src/main/java/example/naoki/ble_myo/ListActivity.java
@@ -30,6 +30,9 @@ public class ListActivity extends ActionBarActivity implements BluetoothAdapter.
     /** Device Scanning Time (ms) */
     private static final long SCAN_PERIOD = 5000;
 
+    /** Intent code for requesting Bluetooth enable */
+    private static final int REQUEST_ENABLE_BT = 1;
+
     private Handler mHandler;
     private BluetoothAdapter mBluetoothAdapter;
     private BluetoothGatt    mBluetoothGatt;
@@ -130,20 +133,27 @@ public class ListActivity extends ActionBarActivity implements BluetoothAdapter.
     }
 
     public void scanDevice() {
-        deviceNames.clear();
-        // Scanning Time out by Handler.
-        // The device scanning needs high energy.
-        mHandler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                mBluetoothAdapter.stopLeScan(ListActivity.this);
+        // Ensures Bluetooth is available on the device and it is enabled. If not,
+        // displays a dialog requesting user permission to enable Bluetooth.
+        if (mBluetoothAdapter == null || !mBluetoothAdapter.isEnabled()) {
+            Intent enableBtIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
+            startActivityForResult(enableBtIntent, REQUEST_ENABLE_BT);
+        } else {
+            deviceNames.clear();
+            // Scanning Time out by Handler.
+            // The device scanning needs high energy.
+            mHandler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    mBluetoothAdapter.stopLeScan(ListActivity.this);
 
-                adapter.notifyDataSetChanged();
-                Toast.makeText(getApplicationContext(), "Stop Device Scan", Toast.LENGTH_SHORT).show();
+                    adapter.notifyDataSetChanged();
+                    Toast.makeText(getApplicationContext(), "Stop Device Scan", Toast.LENGTH_SHORT).show();
 
-            }
-        }, SCAN_PERIOD);
-        mBluetoothAdapter.startLeScan(ListActivity.this);
+                }
+            }, SCAN_PERIOD);
+            mBluetoothAdapter.startLeScan(ListActivity.this);
+        }
     }
 
 }

--- a/BLE_myo/app/src/main/java/example/naoki/ble_myo/MainActivity.java
+++ b/BLE_myo/app/src/main/java/example/naoki/ble_myo/MainActivity.java
@@ -34,6 +34,9 @@ public class MainActivity extends ActionBarActivity implements BluetoothAdapter.
     /** Device Scanning Time (ms) */
     private static final long SCAN_PERIOD = 5000;
 
+    /** Intent code for requesting Bluetooth enable */
+    private static final int REQUEST_ENABLE_BT = 1;
+
     private static final String TAG = "BLE_Myo";
 
     private Handler mHandler;
@@ -70,15 +73,22 @@ public class MainActivity extends ActionBarActivity implements BluetoothAdapter.
         deviceName = intent.getStringExtra(ListActivity.TAG);
 
         if (deviceName != null) {
-        // Scanning Time out by Handler.
-        // The device scanning needs high energy.
-            mHandler.postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    mBluetoothAdapter.stopLeScan(MainActivity.this);
-                }
-            }, SCAN_PERIOD);
-            mBluetoothAdapter.startLeScan(this);
+            // Ensures Bluetooth is available on the device and it is enabled. If not,
+            // displays a dialog requesting user permission to enable Bluetooth.
+            if (mBluetoothAdapter == null || !mBluetoothAdapter.isEnabled()) {
+                Intent enableBtIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
+                startActivityForResult(enableBtIntent, REQUEST_ENABLE_BT);
+            } else {
+                // Scanning Time out by Handler.
+                // The device scanning needs high energy.
+                mHandler.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        mBluetoothAdapter.stopLeScan(MainActivity.this);
+                    }
+                }, SCAN_PERIOD);
+                mBluetoothAdapter.startLeScan(this);
+            }
         }
     }
 


### PR DESCRIPTION
This pull request solves issue #6 prompting a popup if Bluetooth is disabled, with buttons to immediately switch on Bluetooth.
- TODO: We should check on method onActivityResult to find out if
       result is confirm and then trigger a startScan/startLeScan
