### PR TITLE
Adding onActivity result after bluetooth activation

### DIFF
--- a/BLE_myo/app/src/main/java/example/naoki/ble_myo/ListActivity.java
+++ b/BLE_myo/app/src/main/java/example/naoki/ble_myo/ListActivity.java
@@ -156,4 +156,11 @@ public class ListActivity extends ActionBarActivity implements BluetoothAdapter.
         }
     }
 
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == REQUEST_ENABLE_BT && resultCode == RESULT_OK){
+            scanDevice();
+        }
+    }
 }

--- a/BLE_myo/app/src/main/java/example/naoki/ble_myo/MainActivity.java
+++ b/BLE_myo/app/src/main/java/example/naoki/ble_myo/MainActivity.java
@@ -142,7 +142,7 @@ public class MainActivity extends ActionBarActivity implements BluetoothAdapter.
 
     public void onClickVibration(View v){
         if (mBluetoothGatt == null || !mMyoCallback.setMyoControlCommand(commandList.sendVibration3())) {
-            Log.d(TAG,"False Vibrate");
+            Log.d(TAG, "False Vibrate");
         }
     }
 
@@ -228,5 +228,18 @@ public class MainActivity extends ActionBarActivity implements BluetoothAdapter.
         });
     }
 
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == REQUEST_ENABLE_BT && resultCode == RESULT_OK){
+            mHandler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    mBluetoothAdapter.stopLeScan(MainActivity.this);
+                }
+            }, SCAN_PERIOD);
+            mBluetoothAdapter.startLeScan(this);
+        }
+    }
 }
 


### PR DESCRIPTION
This PR closes issue #6 adding a check in method `onActivityResult` after bluetooth enable request
Related PR: #7 
